### PR TITLE
composer.json - Generalize version requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   ],
   "require": {
     "composer/installers": "^1.0",
-    "civicrm/civicrm-core" : "4.7.*"
+    "civicrm/civicrm-core" : "self.version"
   },
   "extra": {
     "installer-name": "civicrm"


### PR DESCRIPTION
One of the issues complicating distribution via `composer` is that the
`composer.json` for the Civi-D8 module requires a specific version number.
This patch makes the `composer.json` more general -- for example, v5.1.1 of
`civicrm-drupal-8` would require v5.1.1 of `civirm-core`. This
reduces the amount of administration required for each release.

It's hard to properly test composer metadata changes ahead of time, but I did successfully
initialize an example root project (below) that relied on this dependency:

```bash
## Make a basic D8 site.
civibuild create drupal8-empty
cd drupal8-empty

## Track changes to our local `composer.json` so that we can do diffs and rollbacks.
git init .
cp example.gitignore .gitignore
git add .
git commit -m 'Import D8 skeleton'

## For testing purposes, manually add my local dev copy of `civicrm-drupal-8.git`
## (which includes this particular patch).
composer config repositories.civicrm-drupal-8 vcs file:///home/myuser/bknix/build/dmaster/sites/all/modules/civicrm/d8foo

## Manually add the only forked dependency
composer config repositories.zetacomponents-mail vcs https://github.com/civicrm/zetacomponents-mail.git

## Install `civicrm-drupal-8` and the corresponding `civicrm-core` and any other dependencies
composer require civicrm/civicrm-drupal-8 dev-master

## Spot-check some files that should have been downloaded automatically
ls -l vendor/civicrm/
# total 0
# drwxr-xr-x 46 totten staff 1564 May  1 02:02 civicrm-core
# drwxr-xr-x 12 totten staff  408 May  1 01:56 civicrm-cxn-rpc
# drwxr-xr-x 11 totten staff  374 May  1 01:56 civicrm-setup

cat vendor/civicrm/civicrm-core/xml/version.xml
# <?xml version="1.0" encoding="iso-8859-1" ?>
# <version>
#   <version_no>5.2.alpha1</version_no>
# </version>
```

The key thing that's relevant to this change is that it downloaded the corresponding version of `civicrm-core`.