### PR TITLE
Added missing civicrm initialize

### DIFF
--- a/modules/civicrm_views/src/Plugin/views/relationship/CivicrmLocation.php
+++ b/modules/civicrm_views/src/Plugin/views/relationship/CivicrmLocation.php
@@ -20,6 +20,8 @@ class CivicrmLocation extends RelationshipPluginBase {
   public function __construct(array $configuration, $plugin_id, $plugin_definition, Civicrm $civicrm) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
+    $civicrm->initialize();
+    
     $this->default_location = \CRM_Core_BAO_LocationType::getDefault()->id;
     $this->locations = \CRM_Core_BAO_Address::buildOptions('location_type_id');
 


### PR DESCRIPTION
Without civicrm-initialize Drupal Views throws error: Class 'CRM_Core_BAO_LocationType' not found!
![missing_civicrm_initialize](https://user-images.githubusercontent.com/3306776/42036390-a13481ae-7ae5-11e8-881d-af8188853397.png)
