### PR TITLE
 Use any version of CiviCRM, greater than 5.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   ],
   "require": {
     "composer/installers": "^1.0",
-    "civicrm/civicrm-core" : "4.7.*"
+    "civicrm/civicrm-core" : ">=5.4.0"
   },
   "extra": {
     "installer-name": "civicrm"


### PR DESCRIPTION
So we can install CiviCRM & Drupal 8 via composer.