### PR TITLE
fix logout on user create

### DIFF
--- a/civicrm.user.inc
+++ b/civicrm.user.inc
@@ -19,7 +19,7 @@ function civicrm_user_login(AccountInterface $account) {
  */
 function civicrm_user_insert(AccountInterface $account) {
   $civicrm = \Drupal::service('civicrm');
-  $civicrm->synchronizeUser($account);
+  $civicrm->initialize();
 
   // As per CRM-7858, the email address in CiviCRM isn't always set
   // with a call to synchronize(). So we force this through.

--- a/civicrm.user.inc
+++ b/civicrm.user.inc
@@ -20,6 +20,11 @@ function civicrm_user_login(AccountInterface $account) {
 function civicrm_user_insert(AccountInterface $account) {
   $civicrm = \Drupal::service('civicrm');
   $civicrm->initialize();
+  
+  $userSystem = CRM_Core_Config::singleton()->userSystem;
+  $userSystemID = $userSystem->getBestUFID($account);
+  $uniqId = $userSystem->getBestUFUniqueIdentifier($account);
+  \CRM_Core_BAO_UFMatch::synchronizeUFMatch($user, $userSystemID, $uniqId, 'Drupal', NULL, 'Individual', $isLogin = FALSE);
 
   // As per CRM-7858, the email address in CiviCRM isn't always set
   // with a call to synchronize(). So we force this through.


### PR DESCRIPTION
Current user get's logged out when creating a Drupal account for a CiviCRM contact.
by removing the sync and just initializing CiviCRM this is fixed.