### PR TITLE
Add core resources before rendering content

### DIFF
--- a/src/Civicrm.php
+++ b/src/Civicrm.php
@@ -78,6 +78,9 @@ class Civicrm {
    */
   public function invoke($args) {
     $this->initialize();
+    
+    // Add CSS, JS, etc. that is required for this page.
+    \CRM_Core_Resources::singleton()->addCoreResources();
 
     // CiviCRM will echo/print directly to stdout. We need to capture it so that
     // we can return the output as a renderable array.

--- a/src/Controller/CivicrmController.php
+++ b/src/Controller/CivicrmController.php
@@ -83,9 +83,6 @@ class CivicrmController extends ControllerBase {
       $this->civicrm->synchronizeUser(User::load($this->currentUser()->id()));
     }
 
-    // Add CSS, JS, etc. that is required for this page.
-    \CRM_Core_Resources::singleton()->addCoreResources();
-
     // We set the CiviCRM markup as safe and assume all XSS (an other) issues
     // have already been taken care of.
     $build = [


### PR DESCRIPTION
The other 4 CMSs all behave this way, so this change is for consistency.

See https://lab.civicrm.org/dev/drupal/issues/32