### PR TITLE
civicrm.user.inc - Fix crash when creating user via drush CLI

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -294,6 +294,15 @@ function _civicrm_user_register_form_validate(&$form, FormStateInterface $form_s
 }
 
 /**
+ * Determine if the user is on a CiviCRM generated page.
+ *
+ * i.e. does the form have some civicrm unique token?
+ */
+function civicrm_on_user_page() {
+  return isset($_POST['_qf_default']);
+}
+
+/**
  * Implements hook_theme().
  */
 function civicrm_theme() {

--- a/civicrm.user.inc
+++ b/civicrm.user.inc
@@ -44,7 +44,9 @@ function civicrm_user_insert(AccountInterface $account) {
   // Process any profile form fields that may have been submitted.
   // In particular, this will pick up form fields that were submitted on the
   // user_registration page.
-  \CRM_Core_BAO_UFGroup::getEditHTML($contact_id, '', 2, TRUE, FALSE, NULL, FALSE, $civicrm->getCtype());
+  if (civicrm_on_user_page()) {
+    \CRM_Core_BAO_UFGroup::getEditHTML($contact_id, '', 2, TRUE, FALSE, NULL, FALSE, $civicrm->getCtype());
+  }
 }
 
 /**


### PR DESCRIPTION
For test/triage/demo sites, we must generate a couple user accounts via drush CLI, e.g.

```
cv core:install --cms-base-url="$CMS_URL" ...
drush8 -y en civicrm
drush8 -y user-create --password="$DEMO_PASS" --mail="$DEMO_EMAIL" "$DEMO_USER"
```

The third step crashes. This PR fixes the crash.

```

[bknix-dfl:~/bknix/build/d8prj-re] drush8 -y user-create --password="test" --mail="test$(date +%s)@example.com" "demo$(date +%s)"
Sorry. A non-recoverable error has occurred.
We can't load the requested web page. This page requires cookies to be enabled in your browser settings. Please check this setting and enable cookies (if they are not enabled). Then try again. If this error persists, contact the site administrator for assistance.<br /><br />Site Administrators: This error may indicate that users are accessing this page using a domain or URL other than the configured Base URL. EXAMPLE: Base URL is http://example.org, but some users are accessing the page via http://www.example.org or a domain alias like http://myotherexample.org.<br /><br />Error type: Could not find a valid session key.



#0 /Users/myuser/bknix/build/d8prj-re/vendor/civicrm/civicrm-core/CRM/Core/Controller.php(831): CRM_Core_Error::fatal("We can't load the requested web page. This page requires cookies to be enable...")
#1 /Users/myuser/bknix/build/d8prj-re/vendor/civicrm/civicrm-core/CRM/Core/Controller.php(826): CRM_Core_Controller->invalidKeyCommon()
#2 /Users/myuser/bknix/build/d8prj-re/vendor/civicrm/civicrm-core/CRM/Core/Controller.php(310): CRM_Core_Controller->invalidKey()
#3 /Users/myuser/bknix/build/d8prj-re/vendor/civicrm/civicrm-core/CRM/Core/Controller.php(204): CRM_Core_Controller->key("CRM_Profile_Form_Dynamic", TRUE, FALSE)
#4 /Users/myuser/bknix/build/d8prj-re/vendor/civicrm/civicrm-core/CRM/Core/Controller/Simple.php(66): CRM_Core_Controller->__construct("Dynamic Form Creator", TRUE, 2, "CRM_Profile_Form_Dynamic", TRUE, FALSE)
#5 /Users/myuser/bknix/build/d8prj-re/vendor/civicrm/civicrm-core/CRM/Core/BAO/UFGroup.php(834): CRM_Core_Controller_Simple->__construct("CRM_Profile_Form_Dynamic", "Dynamic Form Creator", 2)
#6 /Users/myuser/bknix/build/d8prj-re/web/modules/contrib/civicrm/civicrm.user.inc(47): CRM_Core_BAO_UFGroup::getEditHTML(2, "", 2, TRUE, FALSE, NULL, FALSE, "Individual")
#7 [internal function](): civicrm_user_insert(Object(Drupal\user\Entity\User))
#8 /Users/myuser/bknix/build/d8prj-re/web/core/lib/Drupal/Core/Extension/ModuleHandler.php(403): call_user_func_array("civicrm_user_insert", (Array:1))
#9 /Users/myuser/bknix/build/d8prj-re/web/core/lib/Drupal/Core/Entity/EntityStorageBase.php(204): Drupal\Core\Extension\ModuleHandler->invokeAll("user_insert", (Array:1))
#10 /Users/myuser/bknix/build/d8prj-re/web/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php(835): Drupal\Core\Entity\EntityStorageBase->invokeHook("insert", Object(Drupal\user\Entity\User))
#11 /Users/myuser/bknix/build/d8prj-re/web/core/lib/Drupal/Core/Entity/EntityStorageBase.php(527): Drupal\Core\Entity\ContentEntityStorageBase->invokeHook("insert", Object(Drupal\user\Entity\User))
#12 /Users/myuser/bknix/build/d8prj-re/web/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php(720): Drupal\Core\Entity\EntityStorageBase->doPostSave(Object(Drupal\user\Entity\User), FALSE)
#13 /Users/myuser/bknix/build/d8prj-re/web/core/lib/Drupal/Core/Entity/EntityStorageBase.php(452): Drupal\Core\Entity\ContentEntityStorageBase->doPostSave(Object(Drupal\user\Entity\User), FALSE)
#14 /Users/myuser/bknix/build/d8prj-re/web/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php(838): Drupal\Core\Entity\EntityStorageBase->save(Object(Drupal\user\Entity\User))
#15 /Users/myuser/bknix/build/d8prj-re/web/core/lib/Drupal/Core/Entity/EntityBase.php(394): Drupal\Core\Entity\Sql\SqlContentEntityStorage->save(Object(Drupal\user\Entity\User))
#16 /Users/myuser/bknix/build/d8prj-re/vendor/drush/drush/src/Drupal/Commands/core/UserCommands.php(236): Drupal\Core\Entity\EntityBase->save()
#17 [internal function](): Drush\Drupal\Commands\core\UserCommands->create("demo1562028450", (Array:22))
```

Before
------

The `user-create` step crashes while handling `civicrm_user_insert()`. Specifically, the call to `\CRM_Core_BAO_UFGroup::getEditHTML()` fails because the D8 CLI environment doesn't have an active session.

After
-----

`civicrm_user_insert()` only calls `UFGroup::getEditHTML()` if it's likely the user-insertion occured on a relevant web-form.

Technical Details
-----------------

The technique here is ported from the CiviCRM-D7 module. (It is not necessarily pretty, but it should be just as functional as D7.) In particular, `civicrm_on_user_page()` is copied verbatim; and in both cases, `civicrm_user_insert()` calls `civicrm_on_user_page()` to decide whether `getEditHTML()` will run.

The overall call-path in the D7 module is *slightly* different.

* D7: `civicrm_user_insert()` => `civicrm_register_data()` => `getEditHTML()`
* D8: `civicrm_user_insert()` => `getEditHTML()`)

... but the substance of the test is similar.