### PR TITLE
dev/drupal#83 Disable qf key validation for forms interact with CMS

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -262,6 +262,7 @@ function _civicrm_get_profiles($contact_id) {
 function civicrm_form_user_register_form_alter(&$form, &$form_state, $form_id) {
   $civicrm = \Drupal::service('civicrm');
   $civicrm->initialize();
+  civicrm_key_disable();
   $html = \CRM_Core_BAO_UFGroup::getEditHTML(NULL, '', NULL, TRUE, TRUE, NULL, FALSE, $civicrm->getCtype());
 
   // Need to disable the page cache.
@@ -284,6 +285,7 @@ function civicrm_form_user_register_form_alter(&$form, &$form_state, $form_id) {
  */
 function _civicrm_user_register_form_validate(&$form, FormStateInterface $form_state) {
   \Drupal::service('civicrm')->initialize();
+  civicrm_key_disable();
   $errors = CRM_Core_BAO_UFGroup::isValid(NULL, '', TRUE);
 
   if (is_array($errors)) {
@@ -316,4 +318,14 @@ function civicrm_theme() {
  */
 function template_preprocess_civicrm_contact(&$vars) {
   $vars['civicrm_contact'] = $vars['elements']['#civicrm_contact'];
+}
+
+/**
+ * Disable civicrm key for all forms that interact with the CMS.
+ *
+ * We do not control the CMS form generation and hence should suppress
+ * qfKey
+ */
+function civicrm_key_disable() {
+  \CRM_Core_Config::singleton()->keyDisable = TRUE;
 }

--- a/civicrm.user.inc
+++ b/civicrm.user.inc
@@ -20,7 +20,7 @@ function civicrm_user_login(AccountInterface $account) {
 function civicrm_user_insert(AccountInterface $account) {
   $civicrm = \Drupal::service('civicrm');
   $civicrm->initialize();
-  
+  civicrm_key_disable();
   $userSystem = CRM_Core_Config::singleton()->userSystem;
   $userSystemID = $userSystem->getBestUFID($account);
   $uniqId = $userSystem->getBestUFUniqueIdentifier($account);


### PR DESCRIPTION
https://lab.civicrm.org/dev/drupal/issues/83