### PR TITLE
Add a new date filter for Civi dates and views integration

### DIFF
--- a/modules/civicrm_views/civicrm_views.views.inc
+++ b/modules/civicrm_views/civicrm_views.views.inc
@@ -626,6 +626,12 @@ function _civicrm_views_field_to_filter_plugin($entity, $field) {
       return [
         'id' => 'numeric',
       ];
+    
+    case CRM_Utils_Type::T_DATE:
+    case CRM_Utils_Type::T_TIMESTAMP:
+      return array(
+        'id' => 'civicrm_date',
+      );
 
     case CRM_Utils_Type::T_ENUM:
     case CRM_Utils_Type::T_STRING:

--- a/modules/civicrm_views/src/Plugin/views/filter/CivicrmDate.php
+++ b/modules/civicrm_views/src/Plugin/views/filter/CivicrmDate.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\civicrm_views\Plugin\views\filter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\views\filter\Date;
+
+/**
+ * Filter to handle dates stored as a formatted date string but compared as a timestamp.
+ *
+ * @ingroup views_filter_handlers
+ *
+ * @ViewsFilter("civicrm_date")
+ */
+class CivicrmDate extends Date {
+    public function query() {
+        $this->ensureMyTable();
+        $field = "$this->tableAlias.$this->realField";
+        $field = "UNIX_TIMESTAMP($field)";
+
+        $info = $this->operators();
+        if (!empty($info[$this->operator]['method'])) {
+            $this->{$info[$this->operator]['method']}($field);
+        }
+    }
+}


### PR DESCRIPTION
Allow timestamps and dates in civi to be filtered in Views using a modification of the standard Date filter.  This may not be practical for all possible configurations but is better than the ability being completely missing.