### PR TITLE
dev/drupal#54 Remove hook_user_login, fixes the masquerade module

### DIFF
--- a/civicrm.user.inc
+++ b/civicrm.user.inc
@@ -11,6 +11,18 @@ use Drupal\Core\Session\AccountInterface;
  * Implements hook_user_login().
  */
 function civicrm_user_login(AccountInterface $account) {
+  $civicrm = \Drupal::service('civicrm');
+  $civicrm->initialize();
+
+  if (\Drupal::hasService('masquerade')) {
+    // https://github.com/civicrm/civicrm-drupal-8/pull/31
+    // In theory this is harmless whether we masquerade or not, but for now narrowing
+    // the scope, in case it causes regressions.
+    // Not using isMasquerading() because it does not seem to be
+    // initialized at this point (it always returns false).
+    \CRM_Core_Session::singleton()->reset(FALSE);
+  }
+
   \Drupal::service('civicrm')->synchronizeUser($account);
 }
 


### PR DESCRIPTION
The hook_user_login implementation was added by Torrance during the initial port to Drupal8. The Drupal7 implementation does not implement this hook.

It causes problems with the Drupal 'masquerade' module, causing the user to be logged out when attempting to masquerade. This is because the synchronizeUser() function resets the PHP session.

More details here:  
https://lab.civicrm.org/dev/drupal/issues/54#note_23652

I tested the following use-cases:

- As a Drupal admin, I created a new Drupal user, then logged-in with that user. The contact+user were in sync.
- As a CRM admin, with the Actions -> Create CMS account, I created a Drupal account for a user, then logged-in with that account. Also OK.

Looking on the initial commit (29b7571eb11fda770d98ba0cb6ab622e3ce3df3d), there doesn't seem to be a reason for the hook, so it feels safe to remove.