### PR TITLE
dev/core#183 civicrm_requirements() - Use classloader like civicrm_install()

### DIFF
--- a/civicrm.install
+++ b/civicrm.install
@@ -22,9 +22,7 @@ function civicrm_install() {
   }
 
   $civicrm_base = _civicrm_find_civicrm();
-
-  require_once $civicrm_base . '/CRM/Core/ClassLoader.php';
-  CRM_Core_ClassLoader::singleton()->register();
+  _civicrm_classloader($civicrm_base);
 
   // The civicrm install process uses globals all over the place. Ideally these
   // will go sometime soon and will be passed as explicit parameters.
@@ -77,7 +75,6 @@ function civicrm_requirements($phase) {
   $civicrm_base = _civicrm_find_civicrm();
 
   if ($civicrm_base) {
-    require_once $civicrm_base . '/Civi/Install/Requirements.php';
     $requirements['civicrm.location'] = [
       'title' => 'CiviCRM location',
       'value' => $civicrm_base,
@@ -94,6 +91,8 @@ function civicrm_requirements($phase) {
     ];
     return $requirements;
   }
+
+  _civicrm_classloader($civicrm_base);
 
   // Grab db connection info.
   $db_config = _civicrm_get_db_config()['info'];
@@ -154,6 +153,11 @@ function _civicrm_find_civicrm() {
   }
 
   return NULL;
+}
+
+function _civicrm_classloader($civicrm_base) {
+  require_once $civicrm_base . '/CRM/Core/ClassLoader.php';
+  CRM_Core_ClassLoader::singleton()->register();
 }
 
 /**

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   ],
   "require": {
     "composer/installers": "^1.0",
-    "civicrm/civicrm-core" : ">=5.4.0"
+    "civicrm/civicrm-core" : ">=5.21.0"
   },
   "extra": {
     "installer-name": "civicrm"


### PR DESCRIPTION
Overview
--------

This is an off-shoot of https://github.com/civicrm/civicrm-core/pull/15796 inspired by https://lab.civicrm.org/dev/core/issues/183.  In 15796, the `Civi\Install\Requirements` class would be updated to use another helper class.  This relies on autoloading, and that currently fails in D8's `civicrm_requirements()`.

Before
------

* `civicrm_install()` locates Civi code (`ClassLoader.php`) and sets it up
* `civicrm_requirements()` locates Civi code (`ClassLoader.php`) and manually loads a specific class file.

After
-----

* `civicrm_install()` and `civicrm_requirements()` use the same process to locate and initialize the classloader.

Comments
--------

I have one reservation here - the edge-case in which someone has tweaked out `civicrm.settings.php` with a non-default value of `$civicrm_root` (i.e. wherein `$civicrm_root !== _civicrm_find_civicrm()`).  Such a scenario may become more prone to duplicate-class-definition errors if `hook_requirements` runs in a pageview where CiviCRM is initialized. (To wit: if `civicrm_requirements()` and `\Civicrm::initialize()` both execute but use different basepaths, then the same calsses can be available at different file-paths.)

Some possible resolutions are:

* Do nothing else. The edge-case may not even be real for any D8 sites.
* Further refactor such that:
    * In pre-install environments, `civicrm_install()` and `civicrm_requirements()`  use the same process -- calling `_civicrm_find_civicrm()` and loading the classloader
    * In post-install environments, `civicrm_requirements()` and `\Civicrm::initialize()` use the same process -- loading `civicrm.settings.php` and `CRM/Core/ClassLoader.php`.

(NOTE: I personally don't care about 15796 enough to do the second anytime soon -- I'd be just as happy letting these changes wait.  But since I put a bit of time into testing 15796, it seemed prudent to share this iteration.)
