### PR TITLE
dev/drupal#4 - Switch automatic installation to use the civicrm-setup API

### DIFF
--- a/civicrm.install
+++ b/civicrm.install
@@ -5,65 +5,22 @@
  * Contains install-time code for the CiviCRM module.
  */
 
-use Drupal\Core\StreamWrapper\PublicStream;
-use Civi\Install\Requirements;
-use Drupal\Core\Site\Settings;
 use Drupal\Core\Database\Database;
 
 /**
  * Contains things that need to be installed when the module is installed.
  */
 function civicrm_install() {
-  // If civicrm.settings.php file is already present, we assume CiviCRM is
-  // already installed and abort.
-  if (file_exists(\Drupal::service('kernel')->getSitePath() . '/civicrm.settings.php')) {
+  /** @var \Civi\Setup $setup */
+  $setup = _civicrm_setup();
+
+  $installed = $setup->checkInstalled();
+  if ($installed->isSettingInstalled() || $installed->isDatabaseInstalled()) {
     drupal_set_message(t("CiviCRM appears to have already been installed. Skipping full installation."));
-    return;
   }
 
-  $civicrm_base = _civicrm_find_civicrm();
-  _civicrm_classloader($civicrm_base);
-
-  // The civicrm install process uses globals all over the place. Ideally these
-  // will go sometime soon and will be passed as explicit parameters.
-  // @codingStandardsIgnoreStart
-  global $crmPath, $cmsPath, $installType;
-  // @codingStandardsIgnoreEnd
-  $crmPath = $civicrm_base;
-  $cmsPath = \Drupal::root();
-  $installType = 'drupal';
-
-  // Get database connection details.
-  // We attempt to get a separate set of details for a civicrm database, but
-  // otherwise default to using the same database as Drupal.
-  $drupal_db = Database::getConnection('default')->getConnectionOptions();
-  $civicrm_db = _civicrm_get_db_config()['info'];
-
-  $config = [
-    'cms' => 'Drupal8',
-    'base_url' => $GLOBALS['base_url'],
-    // Remove leading 'sites/'.
-    'site_dir' => substr(\Drupal::service('kernel')->getSitePath(), 6),
-    'loadGenerated' => Settings::get('civicrm_load_generated', FALSE),
-    'mysql' => [
-      'username' => $civicrm_db['username'],
-      'password' => $civicrm_db['password'],
-      'server' => "{$civicrm_db['host']}:{$civicrm_db['port']}",
-      'database' => $civicrm_db['database'],
-    ],
-    'cmsdb' => [
-      'username' => $drupal_db['username'],
-      'password' => $drupal_db['password'],
-      'server' => "{$drupal_db['host']}:{$drupal_db['port']}",
-      'database' => $drupal_db['database'],
-    ],
-  ];
-
-  require_once "{$civicrm_base}/install/civicrm.php";
-  // @TODO: Enable CiviCRM's CRM_Core_TemporaryErrorScope::useException() and
-  // possibly catch exceptions. At the moment, civicrm doesn't allow exceptions
-  // to bubble up to Drupal. See CRM-15022.
-  civicrm_main($config);
+  $setup->installFiles();
+  $setup->installDatabase();
 }
 
 /**
@@ -77,7 +34,6 @@ function civicrm_requirements($phase) {
   if ($civicrm_base) {
     $requirements['civicrm.location'] = [
       'title' => 'CiviCRM location',
-      'value' => $civicrm_base,
       'severity' => REQUIREMENT_OK,
       'description' => 'CiviCRM core directory',
     ];
@@ -85,46 +41,79 @@ function civicrm_requirements($phase) {
   else {
     $requirements['civicrm.location'] = [
       'title' => 'CiviCRM location',
-      'value' => NULL,
       'severity' => REQUIREMENT_ERROR,
       'description' => 'CiviCRM must be installed via composer.',
     ];
     return $requirements;
   }
 
-  _civicrm_classloader($civicrm_base);
-
-  // Grab db connection info.
-  $db_config = _civicrm_get_db_config()['info'];
-
-  $install_requirements = new Requirements();
-
-  // Gather directories that need to be writable.
-  $file_paths = [];
-  if (!file_exists(\Drupal::service('kernel')->getSitePath() . '/civicrm.settings.php')) {
-    // eg. sites/default folder.
-    $file_paths[] = realpath(\Drupal::service('kernel')->getSitePath());
-  }
-  // eg. sites/default/files folder.
-  $file_paths[] = realpath(PublicStream::basePath());
-
-  // Attempt to make directories writable
-  // We don't bother checking if these attempts are actually successful as
-  // that will be checked by checkAll().
-  foreach ($file_paths as $path) {
-    @chmod($path, 0755);
+  /** @var \Civi\Setup $setup */
+  $setup = _civicrm_setup();
+  if ($phase === 'install' && !$setup->checkAuthorized()->isAuthorized()) {
+    $requirements['civicrm.checkAuthorized'] = [
+      'title' => 'CiviCRM Installation Not Authorized',
+      'description' => 'The current user does not have sufficient permissions to perform installation.',
+      'severity' => REQUIREMENT_WARNING,
+    ];
+    return $requirements;
   }
 
-  foreach ($install_requirements->checkAll(['db_config' => $db_config, 'file_paths' => $file_paths]) as $key => $result) {
-    $requirements["civicrm.$key"] = [
-      'title' => $result['title'],
-      'value' => NULL,
-      'severity' => $result['severity'],
-      'description' => $result['details'],
+  $severityMap = [
+    'info' => REQUIREMENT_OK,
+    'warning' => REQUIREMENT_WARNING,
+    'error' => REQUIREMENT_ERROR,
+  ];
+  $sections = [
+    'system' => 'CiviCRM: System',
+    'database' => 'CiviCRM: Database',
+    'other' => 'CiviCRM: Other',
+  ];
+
+  foreach ($setup->checkRequirements()->getMessages() as $msg) {
+    $section = isset($sections[$msg['section']]) ? $sections[$msg['section']] : $sections['other'];
+    $key = 'civicrm.' . $msg['section'] . '.' . $msg['name'];
+    $requirements[$key] = [
+      'title' => $section . ': ' . $msg['message'],
+      'description' => $section . ': ' . $msg['message'],
+      'severity' => $severityMap[$msg['severity']],
     ];
   }
 
+  ksort($requirements);
+
   return $requirements;
+}
+
+/**
+ * @return \Civi\Setup
+ */
+function _civicrm_setup() {
+  if (defined('CIVI_SETUP')) {
+    return Civi\Setup::instance();
+  }
+
+  $civicrm_base = _civicrm_find_civicrm();
+  require_once $civicrm_base . '/CRM/Core/ClassLoader.php';
+  CRM_Core_ClassLoader::singleton()->register();
+
+  \Civi\Setup::assertProtocolCompatibility(1.0);
+  \Civi\Setup::init([
+    'cms' => 'Drupal8',
+    'srcPath' => $civicrm_base,
+  ]);
+
+  $setup = Civi\Setup::instance();
+
+  // FIXME: Move more of this to plugins/init/Drupal8.civi-setup.php.
+  $civicrm_db = _civicrm_get_db_config()['info'];
+  $setup->getModel()->db = [
+    'server' => \Civi\Setup\DbUtil::encodeHostPort($civicrm_db['host'], $civicrm_db['port'] ?: NULL),
+    'username' => $civicrm_db['username'],
+    'password' => $civicrm_db['password'],
+    'database' => $civicrm_db['database'],
+  ];
+
+  return $setup;
 }
 
 /**
@@ -153,11 +142,6 @@ function _civicrm_find_civicrm() {
   }
 
   return NULL;
-}
-
-function _civicrm_classloader($civicrm_base) {
-  require_once $civicrm_base . '/CRM/Core/ClassLoader.php';
-  CRM_Core_ClassLoader::singleton()->register();
 }
 
 /**

--- a/civicrm.install
+++ b/civicrm.install
@@ -14,6 +14,12 @@ function civicrm_install() {
   /** @var \Civi\Setup $setup */
   $setup = _civicrm_setup();
 
+  if ($setup->getPendingAction() !== NULL) {
+    // Ex: If you do an advanced installation with `cv core:install`, then
+    // `hook_install` shouldn't activate the default/unconfigured install.
+    return;
+  }
+
   $installed = $setup->checkInstalled();
   if ($installed->isSettingInstalled() || $installed->isDatabaseInstalled()) {
     drupal_set_message(t("CiviCRM appears to have already been installed. Skipping full installation."));

--- a/civicrm.install
+++ b/civicrm.install
@@ -127,6 +127,12 @@ function _civicrm_setup() {
  *   if we can't.
  */
 function _civicrm_find_civicrm() {
+  // TODO: This works with standard composer layouts but would be easy to break
+  // via installer-paths. However, it should be possible to replace this - since we
+  // can count on composer's autoloader being setup already. Some ideas:
+  //  - Use ReflectionClass('Civi') to find the path
+  //  - Update `Civi.php` to provide a function with its __DIR__
+
   $possible_paths = [];
 
   if ($path = drupal_get_path('module', 'civicrm')) {


### PR DESCRIPTION
Overview
---------

In the Civi-D8 module, the CiviCRM installation can be done automatically. (*It doesn't have to be automatic -- one can use `cv core:install` for more advanced installation options. But that's not the main focus of this PR.*)

The automatic installation relies on functionality in core to do the installation. This PR switches from older core functions to newer core functions. In the process, it addresses a structural issue involving SQL schema and `composer`-based sites.

See also:

* https://lab.civicrm.org/dev/core/issues/1615
* https://lab.civicrm.org/dev/drupal/issues/4

Before
-------

* `hook_install` performs an automatic installation by calling `$civicrm_base/install/civicrm.php`.
* `hook_requirements` uses `Civi\Install\Requirements.php` to check pre-install requirements.
* You must have various `*.mysql` files in the `civicrm-core` tree. These files are generated via `GenCode` and are not stored in `civicrm-core.git`. This is a key reason why the `roundearth/civicrm-composer-plugin` (for Civi-D8) downloads an extra copy of the Civi-D7 tarball.

After
-----

* `hook_install` performs an automatic installation by calling the [Setup API](https://github.com/civicrm/civicrm-dev-docs/pull/765/)
* `hook_requirements` uses Setup API to check pre-install requirements.
* SQL schema are generated on the fly - you don't need to have `*.mysql` files.

QA / Testing: Installation
-----------------

The main issue is exploring different installation scenarios. Some of these are covered by automated testing, some aren't. I've tested a considerable number of scenarios during development, and it would be painful for a reviewer to try to do all the same cases, so let me outline the cases I tried (and hopefully a reviewer can direct their energy at the cases I didn't think about).

Consider a QA matrix of different file structures (e.g. `drupal8-clean` or `d8prj-re`) versus activation workflows (e.g. `cv core:install` or `drush en civicrm` or activating via web UI). For each combination, one prepares a new build and spot-checks a few pages in the CiviCRM UI. These are my latest results (circa Feb 26) from testing this branch in each case:

| Workflow                 | (1) `drupal8-clean` | (2) `d8rec-clean` | (3) `d8prj-re` |
| ------------------------ | ------------------- | ----------------- | -------------- |
| (A) Using `cv core:install`    | ok                  | ok                | skip           |
| (B) Using `drush en`     | ok                  | ok                | ok    |
| (C) Using web enable     | ok                  | ok                | ok   |

For some use-cases, my test-scenario was afflicted by other/pre-existing issues (such as [dev/drupal#106](https://lab.civicrm.org/dev/drupal/issues/106) and [dev/drupal#107](https://lab.civicrm.org/dev/drupal/issues/107)) - but most of those have work-arounds or pending patches, so I simply followed those. Those aspects are no better or worse than before.

For a more thorough description of how I went through each use-case, see the remaining notes below.

### QA / Testing: Installation: (A) Using `cv core:install`

`cv core:install` allows one to set some install options (e.g. `loadGenerated` and `siteKey`). The `civibuild` scripts ordinarily use these options to instrument consistent dev builds.

For each build-type, one can just call `civibuild create` to try it out:

```
## Make a test site for scenario (A,1) aka "a1"
civibuild create a1 --type drupal8-clean --civi-ver master \
  --patch https://github.com/civicrm/civicrm-drupal-8/pull/37 \
  --patch https://github.com/civicrm/civicrm-drupal-8/pull/38

## Make a test site for scenario (A,2) aka "a2"
civibuild create a2 --type d8rec-clean --civi-ver master \
  --patch https://github.com/civicrm/civicrm-drupal-8/pull/37 \
  --patch https://github.com/civicrm/civicrm-drupal-8/pull/38

# Skipped: I didn't bother with civibuild+d8prj-re. Column 3 is more laborious to test,
# and we've got a lot of coverage in the rest of matrix.
```

Then login to each site as `demo` and:

* Click "CiviCRM" in the main menu and ensure the page looks right.
* Go to the "New Mailing" page  and ensure the page looks right.

### QA / Testing: Installation: (B) Using `drush en civicrm`

`drush en` is a common way for Drupal admins to activate a module. The Civi-D8 integration currently has auto-install semantics (with various defaults), so I'm testing for equivalence.

For testing, prepare by editing `app/config/{drupal8-clean,d8rec-clean,d8prj-re}/install.sh` to disable the Civi installation steps and demo data/roles/perms. Then

```
civibuild create b1 --type drupal8-clean --civi-ver master \
  --patch https://github.com/civicrm/civicrm-drupal-8/pull/37 \
  --patch https://github.com/civicrm/civicrm-drupal-8/pull/38

civibuild create b2 --type d8rec-clean --civi-ver master \
  --patch https://github.com/civicrm/civicrm-drupal-8/pull/37 \
  --patch https://github.com/civicrm/civicrm-drupal-8/pull/38

civibuild download b3 --type d8prj-re --civi-ver 5.21
cd b3
git scan am ';roundearth/civicrm-composer-plugin;https://gist.githubusercontent.com/totten/16f4a328911e404a72b0dd1f649f326c/raw/ae845f132ffa61fa54b761704ed796c6bacb3b39/0001-Use-master-code.patch'
composer require civicrm/civicrm-{core,packages,drupal-8}:dev-master pear/net_smtp:~1.9.0 zetacomponents/mail:~1.9.0
git scan am https://github.com/civicrm/civicrm-drupal-8/pull/{37,38}
civibuild install b3
```

Then:

* Login as `admin`
* On CLI, run `drush en civicrm -y -l http://MYDOMAIN.bknix:8001/`
* (For d8prj-re) Run `cv api setting.create 'userFrameworkResourceURL=[cms.root]/libraries/civicrm'`
* (For d8prj-re, per [dev/drupal#106](https://lab.civicrm.org/dev/drupal/issues/106)) Edit `civicrm.settings.php` to add:
    ```
    $civicrm_paths['civicrm.root']['url'] = '/libraries/civicrm/';
    $civicrm_paths['civicrm.packages']['url'] = '/libraries/civicrm/packages/';
    ```
* Reload home page. Click "CiviCRM" in the main menu and ensure the page looks right.
* Go to the "New Mailing" page  and ensure the page looks right.

### QA / Testing: Installation: (C) Using web-based Drupal module activation

It's also common for Drupal admins to enable modules by navigating to the "Extend" screen. The Civi-D8 integration currently has auto-install semantics (with various defaults), so I'm testing for equivalence.

For testing, we use the same preparation (editing `app/config/{drupal8-clean,d8rec-clean,d8prj-re}/install.sh`) as in (B). And we use the same commands to setup the build (but swap the names `b1`/`b2`/`b3` with `c1`/`c2`/`c3`).

Then

* Login as `admin`
* Navigate to "Extend" and enable CiviCRM
* (For d8prj-re) Run `cv api setting.create 'userFrameworkResourceURL=[cms.root]/libraries/civicrm'
* (For d8prj-re, per [dev/drupal#106](https://lab.civicrm.org/dev/drupal/issues/106)) Edit `civicrm.settings.php` to add:
    ```
    $civicrm_paths['civicrm.root']['url'] = '/libraries/civicrm/';
    $civicrm_paths['civicrm.packages']['url'] = '/libraries/civicrm/packages/';
    ```
* Reload home page. Click "CiviCRM" in the main menu and ensure the page looks right.
* Go to the "New Mailing" page  and ensure the page looks right.


*Note: During testing,  https://github.com/civicrm/civicrm-core/pull/16628 was opened and then merged. Some tests involved applying that PR manually (pre-merge) and some had it post-merge, but one way or another it was part of all tests.*

QA / Testing: Requirements Check
-----------------

The patch also updates the `hook_requirements` implementation to use Setup API. You can see a quick demonstration of this in a scenario like B1 (using `drush en civicrm` with `drupal8-clean`).

* If you just say `drush en civicrm`, it should complain and prompt you to fix one of the failing requirements. Specifically, it can't install without knowing the site's real URL.
* If you say `cv core:check-req` or `cv core:check-req -ew`, then you can see the requirements-check in a nicer format.
* If you use `drush en civicrm` and specify the site's URL (`--url` or `-l`), then the install can proceed. Example: `drush en civicrm -y -l http://b1.bknix:8001/ `

I recall doing some earlier testing+debugging in CLI+web UI, so that should be working, but it's a little involved (e.g. if your web+mysql are already setup well, then you have to hack something to provoke an error -- e.g. putting some unrealistic constants in `Civi/Install/Requirements.php` or making `sites/default` read-only).