### PR TITLE
dev/drupal#107 - Fix user<=>contact sync used by installation workflow

### DIFF
--- a/src/Controller/CivicrmController.php
+++ b/src/Controller/CivicrmController.php
@@ -69,6 +69,11 @@ class CivicrmController extends ControllerBase {
     // Need to disable the page cache.
     \Drupal::service('page_cache_kill_switch')->trigger();
 
+    // Synchronize the Drupal user with the Contacts database (dev/drupal#107)
+    if (!$this->currentUser()->isAnonymous()) {
+      $this->civicrm->synchronizeUser(User::load($this->currentUser()->id()));
+    }
+
     // @Todo: Enable CiviCRM's CRM_Core_TemporaryErrorScope::useException() and
     // possibly catch exceptions. At the moment, civicrm doesn't allow
     // exceptions to bubble up to Drupal. See CRM-15022.
@@ -76,11 +81,6 @@ class CivicrmController extends ControllerBase {
 
     if ($this->civicrmPageState->isAccessDenied()) {
       throw new AccessDeniedHttpException();
-    }
-
-    // Synchronize the Drupal user with the Contacts database (why?)
-    if (!$this->currentUser()->isAnonymous()) {
-      $this->civicrm->synchronizeUser(User::load($this->currentUser()->id()));
     }
 
     // We set the CiviCRM markup as safe and assume all XSS (an other) issues


### PR DESCRIPTION
Overview
--------

This fixes a bug which primarily manifests for the administrator during a new Civi-D8 installation.

See: https://lab.civicrm.org/dev/drupal/issues/107

Before
------

Two ways to look at this:

(A) __Main symptom__ - After enabling CiviCRM on D8, you navigate to the CiviCRM dashboard and get a weird error like:

> Sorry, due to an error, we are unable to fulfill your request at the moment. You may want to contact your administrator or service provider with more details about what action you were performing
>
> DB Constraint Violation - contact_id should possibly be marked as mandatory for DashboardContact,create API. If so, please raise a bug report.

(B) __Formal description__ - If (for whatever reason) a D8 user is not linked to a Civi contact, then any attempt to work with the active user/contact will fail. (This affects the admin user during installation... but it likely affects *all* users/sessions that exist around the time of installation, and it also likely affects some edge-cases when working with DB snapshots.)

After
-----

(A) __Main symptom__ - After enabling CiviCRM on D8, you can start using CiviCRM. No need to logout/login.

(B) __Formal description__ - If (for whatever reason) a D8 user is not linked to a Civi contact, and if the user tries to use a `civicrm` page, then a contact will be created and linked.

Technical Details
-----------------

This same technique has been active in Civi-D7 for years. (It seems to go back at least as far as the svn=>git migration.)

The code for this technique was present in Civi-D8, but it had some comments indicating that its significance wasn't understood at the time of porting, and it was run at the wrong moment (i.e. *after* the page-execution).

Aside: I've been doing my local testing in hacked-up variant of the [drupal8-clean](https://github.com/civicrm/civicrm-buildkit/tree/master/app/config/drupal8-clean) configuration -- specifically, editing `install.sh` to omit the automated Civi installation and also using #37. However, I believe this would fix the symptom in other configurations.