### PR TITLE
Replace deprecated drupal_set_message

### DIFF
--- a/src/Form/UserProfile.php
+++ b/src/Form/UserProfile.php
@@ -125,7 +125,7 @@ class UserProfile extends FormBase {
     // Somehow, somewhere, CiviCRM is processing our form. I have no idea how.
     // Invalidate caches for user, so that latest profile information shows.
     Cache::invalidateTags(['user:' . $this->user->id()]);
-    drupal_set_message($this->t("Profile successfully updated."));
+    $this->messenger()->addMessage($this->t("Profile successfully updated."));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
drupal_set_message is deprecated in drupal 8.5+

To check the replacement is working:
1. Create a civi profile that has `View/Edit Drupal User Account` checked under "Used For".
2. Clear drupal cache at admin/config/development/performance (otherwise the tab in the next step won't show up).
3. Edit any user record under /admin/people.
4. Click on the tab for the profile you made.
5. Fill it out and save it.
6. It should still give the same message as before: "Profile successfully updated."

Technical Details
----------------------------------------
The Messenger service is already injected into any forms that extend drupal forms, so we can just use it as `$this->messenger()`.

Comments
----------------------------------------
There's some other E_NOTICEs and problems on this page (like it doesn't load any civi javascript) but this is just about the drupal_set_message() function.
