### PR TITLE
Make CiviCRM modules installable on D9.

### DIFF
--- a/civicrm.info.yml
+++ b/civicrm.info.yml
@@ -2,4 +2,4 @@ name: CiviCRM Core
 type: module
 description: 'Constituent Relationship Management system. Allows sites to manage contacts, relationships and groups, and track contact activities, contributions, memberships and events.'
 package: CiviCRM
-core: 8.x
+core_version_requirement: ^8.7.7 || ^9

--- a/modules/civicrmtheme/civicrmtheme.info.yml
+++ b/modules/civicrmtheme/civicrmtheme.info.yml
@@ -2,6 +2,6 @@ name: CiviCRM Theme
 type: module
 description: 'Define alternate themes for CiviCRM.'
 package: CiviCRM
-core: 8.x
+core_version_requirement: ^8.7.7 || ^9
 dependencies:
  - civicrm


### PR DESCRIPTION
As the title says! This makes the two CiviCRM modules installable on both D8.7.7 and up as well as D9. 