### PR TITLE
dev/drupal/#137 updates hook requirements adds sanity check, remove install checks 

### DIFF
--- a/civicrm.install
+++ b/civicrm.install
@@ -33,6 +33,42 @@ function civicrm_install() {
  * Implements hook_requirements().
  */
 function civicrm_requirements($phase) {
+
+  if ($phase == 'runtime') {
+
+    $requirements = [];
+
+    // Check we have a functioning civicrm instance.
+    $civicrm =  \Drupal::service('civicrm');
+    $civicrm->initialize();
+    if (!$civicrm->isInitialized()) {
+      $requirements['civicrm.intialized'] = [
+      'title' => 'CiviCRM Initialized',
+      'severity' => REQUIREMENT_ERROR,
+      'description' => t('Civicrm failed to Initialize. For further information see the <a href=":url">install guide</a>', [':url' => 'https://docs.civicrm.org/installation/en/latest/drupal8/']),
+      ];
+      return $requirements;
+    }
+
+    // Civicrm Initialize ran.
+    // Check that civicrm.settings.php is not writable.
+
+    if (is_writable(CIVICRM_SETTINGS_PATH)){
+      $requirements['civicrm.settingsfile'] = [
+      'title' => 'CiviCRM Settings File writeable',
+      'severity' => REQUIREMENT_WARNING,
+      'description' => t('civicrm.settings.php should not be writable. Please check the
+permissions on this file. For more information see <a href=":url">install guide</a>', [':url' => 'https://docs.civicrm.org/installation/en/latest/drupal8/']),
+      ];
+    }
+
+    // @todo include further checks here to confirm that civicrm is
+    // healthy - potentially emit errors/warnings from System.check
+    return $requirements;
+
+  }
+
+
   $requirements = [];
 
   $civicrm_base = _civicrm_find_civicrm();

--- a/civicrm.install
+++ b/civicrm.install
@@ -39,13 +39,13 @@ function civicrm_requirements($phase) {
     $requirements = [];
 
     // Check we have a functioning civicrm instance.
-    $civicrm =  \Drupal::service('civicrm');
+    $civicrm = \Drupal::service('civicrm');
     $civicrm->initialize();
     if (!$civicrm->isInitialized()) {
-      $requirements['civicrm.intialized'] = [
-      'title' => 'CiviCRM Initialized',
-      'severity' => REQUIREMENT_ERROR,
-      'description' => t('Civicrm failed to Initialize. For further information see the <a href=":url">install guide</a>', [':url' => 'https://docs.civicrm.org/installation/en/latest/drupal8/']),
+      $requirements['civicrm.initialized'] = [
+        'title' => 'CiviCRM Initialized',
+        'severity' => REQUIREMENT_ERROR,
+        'description' => 'CiviCRM failed to Initialize. For further information see the <a href="https://docs.civicrm.org/installation/en/latest/drupal8/">install guide</a>',
       ];
       return $requirements;
     }
@@ -53,11 +53,11 @@ function civicrm_requirements($phase) {
     // Civicrm Initialize ran.
     // Check that civicrm.settings.php is not writable.
 
-    if (is_writable(CIVICRM_SETTINGS_PATH)){
+    if (is_writable(CIVICRM_SETTINGS_PATH)) {
       $requirements['civicrm.settingsfile'] = [
-      'title' => 'CiviCRM Settings File writeable',
-      'severity' => REQUIREMENT_WARNING,
-      'description' => t('civicrm.settings.php should not be writable. Please check the
+        'title' => 'CiviCRM Settings File writeable',
+        'severity' => REQUIREMENT_WARNING,
+        'description' => t('civicrm.settings.php should not be writable. Please check the
 permissions on this file. For more information see <a href=":url">install guide</a>', [':url' => 'https://docs.civicrm.org/installation/en/latest/drupal8/']),
       ];
     }


### PR DESCRIPTION
hook_requirements  didn't account for it being called post install. This PR adds a very quick sanity check - is civicrm initialised and is civicrm.settings.php writable.

The check on is civicrm initialised to match behaviour on D7.
It's possible we should add some behaviour here to catch the case where the installer hasn't run? However as the installer isn't being used on D8 currently - and it installs on enabling this is probably surplus to requirements for now.

Rationale for adding the check on civicrm.settings.php (and nothing else) is due to the previous behaviour which warned if it was not writable. Potentially this could be an error? But have left as a warning for now.