### PR TITLE
dev/drupal#122 - getUsername() is deprecated

### DIFF
--- a/src/Form/UserProfile.php
+++ b/src/Form/UserProfile.php
@@ -85,7 +85,7 @@ class UserProfile extends FormBase {
     $this->contactId = \CRM_Core_BAO_UFMatch::getContactId($user->id());
     $html = \CRM_Core_BAO_UFGroup::getEditHTML($this->contactId, $this->ufGroup['title']);
 
-    $form['#title'] = $this->user->getUsername();
+    $form['#title'] = $this->user->getAccountName();
     $form['form'] = [
       '#type' => 'fieldset',
       '#title' => $this->ufGroup['title'],


### PR DESCRIPTION
Related to https://lab.civicrm.org/dev/drupal/-/issues/122

Where this is used is on the drupal user account screen in edit mode when you click on the Name and Address tab that civi provides.

The easiest way to see this is to install drupal 9 with civi and then visit that Name and Address tab. It's difficult to see deprecation notices in drupal 8 for reasons I won't go into here.

https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Session%21AccountInterface.php/function/AccountInterface%3A%3AgetUsername/8.9.x

https://git.drupalcode.org/project/drupal/-/blob/3cd84c3f1790b48315168f73db0789a004173a69/core/modules/user/src/Entity/User.php#L376