### PR TITLE
[REF] Swap out usage of drupal_set_message for an Exception

### DIFF
--- a/civicrm.install
+++ b/civicrm.install
@@ -22,7 +22,7 @@ function civicrm_install() {
 
   $installed = $setup->checkInstalled();
   if ($installed->isSettingInstalled() || $installed->isDatabaseInstalled()) {
-    drupal_set_message(t("CiviCRM appears to have already been installed. Skipping full installation."));
+    throw new \Exception("CiviCRM appears to have already been installed. Skipping full installation.");
   }
 
   $setup->installFiles();


### PR DESCRIPTION
This is an alternate to https://github.com/civicrm/civicrm-drupal-8/pull/45/files as per the comments by @demeritcowboy https://github.com/civicrm/civicrm-drupal-8/pull/45#issuecomment-698982257 @MikeyMJCO @KarinG @mlutfy 