### PR TITLE
dev/drupal#147 - Fix descriptions on drupal 8 permissions page

### DIFF
--- a/src/CivicrmPermissions.php
+++ b/src/CivicrmPermissions.php
@@ -37,10 +37,14 @@ class CivicrmPermissions implements ContainerInjectionInterface {
    */
   public function permissions() {
     $permissions = [];
-    foreach (\CRM_Core_Permission::basicPermissions() as $permission => $title) {
-      // @codingStandardsIgnoreStart
-      $permissions[$permission] = ['title' => $this->t($title)];
-      // @codingStandardsIgnoreEnd
+    foreach (\CRM_Core_Permission::basicPermissions(FALSE, TRUE) as $permission => $attr) {
+      $title = array_shift($attr);
+      $permissions[$permission] = ['title' => $title];
+
+      $description = array_shift($attr);
+      if (!empty($description)) {
+        $permissions[$permission]['description'] = $description;
+      }
     }
     return $permissions;
   }


### PR DESCRIPTION
https://lab.civicrm.org/dev/drupal/-/issues/147

In drupal 8 at /admin/people/permissions the descriptions for civi permissions don't show.

My guess is that when this code was first done drupal 8 itself was still pretty rough, but since roughly the [same code](https://github.com/civicrm/civicrm-drupal/blob/d797aa2767a7dad27d5100b9ae4d2fdc9ae2d994/civicrm.module#L74-L85) as for drupal 7 works I don't know why it's currently like this.

Note also I've removed the `$this->t()` because they're already civi-ts'd when they get here. I suppose there's pros and cons to them already being translated but is a separate topic.