### PR TITLE
dev/core#2286 - Avoid notice on missing db port during install

### DIFF
--- a/civicrm.install
+++ b/civicrm.install
@@ -113,7 +113,7 @@ function _civicrm_setup() {
   // FIXME: Move more of this to plugins/init/Drupal8.civi-setup.php.
   $civicrm_db = _civicrm_get_db_config()['info'];
   $setup->getModel()->db = [
-    'server' => \Civi\Setup\DbUtil::encodeHostPort($civicrm_db['host'], $civicrm_db['port'] ?: NULL),
+    'server' => \Civi\Setup\DbUtil::encodeHostPort($civicrm_db['host'], $civicrm_db['port'] ?? NULL),
     'username' => $civicrm_db['username'],
     'password' => $civicrm_db['password'],
     'database' => $civicrm_db['database'],


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/2286

It's hard to explain how to reproduce this since it only comes up during a certain type of unit test for which there aren't any docs yet, but it comes up there as a fatal error. I'm hoping this is just an easy one from looking at the one-line change.

If the `$civicrm_db` array does not have a `port` member, then the current code gives a notice.

Companion to https://github.com/civicrm/civicrm-core/pull/19324