### PR TITLE
dev/core#2387 - Method of preventing cache for blocks doesn't work

### DIFF
--- a/src/Plugin/Block/CivicrmBlock.php
+++ b/src/Plugin/Block/CivicrmBlock.php
@@ -33,8 +33,6 @@ class CivicrmBlock extends BlockBase implements ContainerFactoryPluginInterface 
    *   The plugin implementation definition.
    */
   public function __construct(Civicrm $civicrm, array $configuration, $plugin_id, $plugin_definition) {
-    // Mark all CiviCRM blocks as uncachable.
-    $configuration['cache']['max_age'] = 0;
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $civicrm->initialize();
   }
@@ -62,6 +60,7 @@ class CivicrmBlock extends BlockBase implements ContainerFactoryPluginInterface 
     if ($content) {
       return [
         '#markup' => Markup::create($content),
+        '#cache' => ['max-age' => 0],
       ];
     }
     return [];


### PR DESCRIPTION
Drupal 8 is super-cachey. The intent was clearly to avoid it but the method used doesn't work. Example to see this is as described in ticket - recent items block doesn't update by itself without clearing drupal cache.

https://lab.civicrm.org/dev/core/-/issues/2387