### PR TITLE
[NFC] Consistency fix when defining CIVICRM_TEST

### DIFF
--- a/tests/src/FunctionalJavascript/CiviCrmTestBase.php
+++ b/tests/src/FunctionalJavascript/CiviCrmTestBase.php
@@ -85,7 +85,7 @@ if (!defined('CIVICRM_CONTAINER_CACHE')) {
   define('CIVICRM_CONTAINER_CACHE', 'never');
 }
 if (!defined('CIVICRM_TEST')) {
-  define('CIVICRM_TEST', 'never');
+  define('CIVICRM_TEST', 1);
 }
 
 CONSTANTS;


### PR DESCRIPTION
I'm guessing this is just a copy/paste from the line above. Everywhere else it gets defined as `1`, so this is just a consistency fix since `never` is effectively the same as `1` when checking `if (defined())`, and to head off future confusion/questions. I can't find anywhere where the exact value is used.

@mglaman 