### PR TITLE
Deprecated function drupal_get_path()

### DIFF
--- a/civicrm.install
+++ b/civicrm.install
@@ -154,7 +154,7 @@ function _civicrm_find_civicrm() {
 
   $possible_paths = [];
 
-  if ($path = drupal_get_path('module', 'civicrm')) {
+  if ($path = \Drupal::service('extension.list.module')->getPath('civicrm')) {
     $possible_paths[] = $path;
   }
   $possible_paths[] = 'vendor/civicrm/civicrm-core';


### PR DESCRIPTION
Deprecated in 9.3: https://www.drupal.org/node/2940438

If you're wondering the replacement works in drupal 8.9 too.

See discussion at https://github.com/civicrm/civicrm-core/pull/21809 for why you can't see this error. The other option is wait until drupal 10 is released and then it will hard crash and then you'll see it, but which frustratingly defeats the purpose of having deprecation messages ahead of time.