### PR TITLE
Allow installing on drupal 10

### DIFF
--- a/civicrm.info.yml
+++ b/civicrm.info.yml
@@ -2,4 +2,4 @@ name: CiviCRM Core
 type: module
 description: 'Constituent Relationship Management system. Allows sites to manage contacts, relationships and groups, and track contact activities, contributions, memberships and events.'
 package: CiviCRM
-core_version_requirement: ^8.7.7 || ^9
+core_version_requirement: ^9 || ^10

--- a/modules/civicrmtheme/civicrmtheme.info.yml
+++ b/modules/civicrmtheme/civicrmtheme.info.yml
@@ -2,6 +2,6 @@ name: CiviCRM Theme
 type: module
 description: 'Define alternate themes for CiviCRM.'
 package: CiviCRM
-core_version_requirement: ^8.7.7 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
  - civicrm


### PR DESCRIPTION
This also removes support for drupal 8 since it's been eol for 6 months and there's no difference between civi on drupal 8 and drupal 9.