### PR TITLE
Use correct user variable in hook_user_insert

### DIFF
--- a/civicrm.user.inc
+++ b/civicrm.user.inc
@@ -36,7 +36,7 @@ function civicrm_user_insert(AccountInterface $account) {
   $userSystem = CRM_Core_Config::singleton()->userSystem;
   $userSystemID = $userSystem->getBestUFID($account);
   $uniqId = $userSystem->getBestUFUniqueIdentifier($account);
-  \CRM_Core_BAO_UFMatch::synchronizeUFMatch($user, $userSystemID, $uniqId, 'Drupal', NULL, 'Individual', $isLogin = FALSE);
+  \CRM_Core_BAO_UFMatch::synchronizeUFMatch($account, $userSystemID, $uniqId, 'Drupal8', NULL, 'Individual', $isLogin = FALSE);
 
   // As per CRM-7858, the email address in CiviCRM isn't always set
   // with a call to synchronize(). So we force this through.


### PR DESCRIPTION
$user is never defined anywhere.

It ends up not making a difference when _creating drupal users via UI_ because the only thing it changes in synchronizeUFMatch is that it reassigns $uniqId (the email address) to $params['email'] a second time before calling Contact.create. i.e. once [here](https://github.com/civicrm/civicrm-core/blob/51ae64d92c18291070b32d7d6e2a02d8ba280b0a/CRM/Core/BAO/UFMatch.php#L183) and then again [here](https://github.com/civicrm/civicrm-core/blob/51ae64d92c18291070b32d7d6e2a02d8ba280b0a/CRM/Core/BAO/UFMatch.php#L242).

The Drupal vs Drupal8 also doesn't make a difference because that param is only used when it's wordpress or joomla.

This surfaced because of https://github.com/civicrm/civicrm-core/pull/23515. There aren't any tests in this repo but there are tests elsewhere that failed, e.g. https://github.com/SemperIT/CiviCARROT/runs/6566995948?check_suite_focus=true#step:19:44, where the drupal user isn't created in the UI.