### PR TITLE
[NFC/Unit tests] Deprecated theme in unit test base class

### DIFF
--- a/tests/src/FunctionalJavascript/CiviCrmTestBase.php
+++ b/tests/src/FunctionalJavascript/CiviCrmTestBase.php
@@ -10,7 +10,7 @@ use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
  */
 abstract class CiviCrmTestBase extends WebDriverTestBase {
 
-  protected $defaultTheme = 'classy';
+  protected $defaultTheme = 'starterkit_theme';
 
   protected static $modules = [
     'block',


### PR DESCRIPTION
The theme is deprecated in 9.5 and removed in 10, but the new one is not available until 9.3, however this only affects community Mink unit tests. See e.g. https://git.drupalcode.org/project/drupal/-/commit/689225c

Apparently there was an even earlier decision that you have to specify something: https://www.drupal.org/node/3083055. So I can't just leave it blank to get a default: `Drupal\Tests\BrowserTestBase::$defaultTheme is required. See https://www.drupal.org/node/3083055, which includes recommendations on which theme to use.`

See e.g. for a test run using this PR: https://github.com/SemperIT/CiviCARROT/actions/runs/3406409291/jobs/5665075348