### PR TITLE
update CiviCrmTestBase setup() method declaration to match BrowserTestBase

### DIFF
--- a/tests/src/FunctionalJavascript/CiviCrmTestBase.php
+++ b/tests/src/FunctionalJavascript/CiviCrmTestBase.php
@@ -20,7 +20,7 @@ abstract class CiviCrmTestBase extends WebDriverTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp() : void {
     parent::setUp();
     $this->drupalPlaceBlock('page_title_block');
     $this->drupalPlaceBlock('local_tasks_block');


### PR DESCRIPTION
Working on a D10 version of CiviCRM Entity
https://github.com/eileenmcnaughton/civicrm_entity/pull/408

Getting error:
`PHP Fatal error:  Declaration of Drupal\Tests\civicrm\FunctionalJavascript\CiviCrmTestBase::setUp() must be compatible with Drupal\Tests\BrowserTestBase::setUp(): void in /home/runner/drupal/web/modules/contrib/civicrm/tests/src/FunctionalJavascript/CiviCrmTestBase.php on line 23`

The function definition has changed:
https://api.drupal.org/api/drupal/core%21tests%21Drupal%21Tests%21BrowserTestBase.php/function/BrowserTestBase%3A%3AsetUp/10

This may break tests for older versions of CiviCRM though? 

Is there a specific branch being used for Drupal 10?
