### PR TITLE
Fix user profile file fields not saving.

### DIFF
--- a/src/Form/UserProfile.php
+++ b/src/Form/UserProfile.php
@@ -90,6 +90,7 @@ class UserProfile extends FormBase {
     \CRM_Core_Resources::singleton()->addCoreResources();
 
     $form['#title'] = $this->user->getAccountName();
+    $form['#attributes'] = ['enctype' => "multipart/form-data"];
     $form['form'] = [
       '#type' => 'fieldset',
       '#title' => $this->ufGroup['title'],


### PR DESCRIPTION
The form must have "enctype" set to "multipart/form-data" for the file to be processed and saved by CiviCRM. Otherwise, any CiviCRM file custom fields won't save when exposed on Drupal user profile forms.

This can be reproduced by adding a file upload custom field to a CiviCRM profile that's connected to the Drupal user profile.