### PR TITLE
Use the backend theme when upgrading

### DIFF
--- a/modules/civicrmtheme/src/Theme/CivicrmThemeNegotiator.php
+++ b/modules/civicrmtheme/src/Theme/CivicrmThemeNegotiator.php
@@ -67,10 +67,6 @@ class CivicrmThemeNegotiator implements ThemeNegotiatorInterface {
       return FALSE;
     }
 
-    if (count($parts) > 1 && $parts[1] == 'upgrade') {
-      return FALSE;
-    }
-
     $config = $this->configFactory->get('civicrmtheme.settings');
     $admin_theme = $config->get('admin_theme');
     $public_theme = $config->get('public_theme');


### PR DESCRIPTION
Related core PR:  
https://github.com/civicrm/civicrm-core/pull/25961

This change was initially introduced in CiviCRM 4.2 to avoid issues when upgrading, but we could not find any reason to keep it that way today. Using the backend theme will make it easier to provide consistent theming accross CMS-es and also usually avoids some frontend CMS features to kick-in, such as Views.