### PR TITLE
Make the `args` route parameter a string, avoiding a TypeError with Drupal 9.5.9

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -349,7 +349,8 @@ function civicrm_theme() {
 function civicrm_preprocess_html(array &$variables) {
   // Get current route name and CiviCRM args parameter.
   $name = \Drupal::routeMatch()->getRouteName();
-  $args = explode('/', \Drupal::routeMatch()->getParameter('args'));
+  $args = \Drupal::routeMatch()->getParameter('args');
+  $args = is_array($args) ? $args : explode('/', $args);
 
   // Get module from route name.
   $segments = explode('.', $name);

--- a/civicrm.module
+++ b/civicrm.module
@@ -349,7 +349,7 @@ function civicrm_theme() {
 function civicrm_preprocess_html(array &$variables) {
   // Get current route name and CiviCRM args parameter.
   $name = \Drupal::routeMatch()->getRouteName();
-  $args = \Drupal::routeMatch()->getParameter('args');
+  $args = explode('/', \Drupal::routeMatch()->getParameter('args'));
 
   // Get module from route name.
   $segments = explode('.', $name);

--- a/src/Controller/CivicrmController.php
+++ b/src/Controller/CivicrmController.php
@@ -56,7 +56,9 @@ class CivicrmController extends ControllerBase {
    * Main controller, passes trough to CiviCRM.
    */
   public function main($args, $extra) {
-    $args = explode('/', $args);
+    // $args should usually be a `string`, but (when upgrading, e.g. from 5.61.0) it may be `array`.
+    $args = is_array($args) ? $args : explode('/', $args);
+
     if ($extra) {
       $args = array_merge($args, explode(':', $extra));
     }

--- a/src/Controller/CivicrmController.php
+++ b/src/Controller/CivicrmController.php
@@ -56,6 +56,7 @@ class CivicrmController extends ControllerBase {
    * Main controller, passes trough to CiviCRM.
    */
   public function main($args, $extra) {
+    $args = explode('/', $args);
     if ($extra) {
       $args = array_merge($args, explode(':', $extra));
     }

--- a/src/Routing/Routes.php
+++ b/src/Routing/Routes.php
@@ -33,7 +33,7 @@ class Routes {
         [
           '_title' => isset($item['title']) ? $item['title'] : 'CiviCRM',
           '_controller' => 'Drupal\civicrm\Controller\CivicrmController::main',
-          'args' => explode('/', $path),
+          'args' => $path,
           'extra' => '',
         ],
         [


### PR DESCRIPTION
Drupal 9.5.9 introduced ([issue](https://www.drupal.org/project/drupal/issues/3277784), [commit](https://git.drupalcode.org/project/drupal/-/commit/a894a04bac8f2cff2339bbfeb7efc7d5413ad241#79885a62ed357d5f1a684244c606e403d58de4f9_69_75)) a change related to route parameters, making the `args` default that *civicrm-drupal-8* adds for every CiviCRM route in `\Drupal\civicrm\Routing\Routes::listRoutes()` a route parameter, that eventually ends up as a translation parameter when translating the route's title in `\Drupal\Core\Controller\TitleResolver::getTitle()`.

As the `args` parameter is an array (and not a string, as route parameters have to be), this causes a `TypeError` when `\Drupal\Component\Utility\Html::escape()`ing the parameter value.

This PR makes the route parameter a string and `explode()`s it only when needed in the route controller and theme preprocessing.

This is rather important as without that fix, CiviCRM is incompatible with Drupal 9.5.9+.

Cc: @demeritcowboy, @mlutfy, @colemanw

Issue raised in the [CiviCRM chat](https://chat.civicrm.org/civicrm/pl/8asb7ygnybn3ubodns1afr7xda) before.