### PR TITLE
generate URLs faster

### DIFF
--- a/src/PathProcessor/CivicrmPathProcessor.php
+++ b/src/PathProcessor/CivicrmPathProcessor.php
@@ -11,43 +11,42 @@ use Drupal\civicrm\Civicrm;
  */
 class CivicrmPathProcessor implements InboundPathProcessorInterface {
 
+  private static $knownPaths;
+  private static $routesInitialized = FALSE;
+
   /**
    * {@inheritdoc}
    */
   public function processInbound($path, Request $request) {
     // If the path is a civicrm path.
     if (strpos($path, '/civicrm/') === 0) {
+      // We've already looked up this path on this page request.
+      if (isset(self::$knownPaths[$path])) {
+        return self::$knownPaths[$path];
+      }
       // Initialize civicrm.
       $civicrm = new Civicrm();
       $civicrm->initialize();
-      // Fetch civicrm menu items.
-      $items = \CRM_Core_Menu::items();
-      $longest = '';
-      foreach (array_keys($items) as $item) {
-        $item = '/' . $item;
-        // If he current path is a civicrm path.
-        if ((strpos($path, $item) === 0)) {
-          // Discover longest matching civicrm path in the request path.
-          if (strlen($item) > strlen($longest)) {
-            $longest = $item;
-          }
-        }
+      $routesAreInDb = \CRM_Core_DAO::singleValueQuery('SELECT COUNT(*) from civicrm_menu');
+      if (!$routesAreInDb && !self::$routesInitialized) {
+        self::$routesInitialized = TRUE;
+        \CRM_Core_Menu::store();
       }
-      if (!empty($longest)) {
+      $pathArray = \CRM_Core_Menu::get(ltrim($path, '/'));
+      // Restore the leading slash.
+      if ($pathArray['path'] ?? FALSE) {
+        $newPath = '/' . $pathArray['path'];
         // Parse url component parameters from path.
-        $params = str_replace($longest, '', $path);
+        $params = str_replace($newPath, '', $path);
         // Replace slashes with colons and the controller will piece it back
         // together.
         if (strlen($params)) {
           $params = str_replace('/', ':', $params);
-          if (substr($params, 0, 1) == ':') {
-            $params = substr($params, 1);
-          }
-          return "$longest/$params";
+          $params = ltrim($params, ':');
+          $newPath .= "/$params";
         }
-        else {
-          return $longest;
-        }
+        self::$knownPaths[$path] = $newPath;
+        return $newPath;
       }
     }
     return $path;


### PR DESCRIPTION
This follows on a [conversation](https://chat.civicrm.org/civicrm/pl/71uisjrdyfbjujz13bwnipph4h) from January with @jackrabbithanna toward addressing the performance of CiviCRM page loads.

We currently call `CRM_Core_Menu::items()` each time `CRM_Core_System::url()` is called.  `url()` is called many times per page - and `CRM_Core_Menu::items()` is a full rebuild of `civicrm_menu` - scanning for and loading XML files, Afforms, anything that can add a route.

This patch cuts an average of 10-12% off every page load time - except search results, which were comparable (I'm not sure why).  It also doesn't change load time for SearchKit AJAX requests - presumably because URLs are generated in JS, not PHP.