### PR TITLE
composer.json - Explicitly allow dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   "require": {
     "composer/installers": "^1 || ^2",
     "civicrm/civicrm-asset-plugin": "~1.1",
-    "civicrm/civicrm-core" : ">=5.21.0"
+    "civicrm/civicrm-core" : ">=5.21.0 || dev-master"
   },
   "extra": {
     "installer-name": "civicrm"


### PR DESCRIPTION
Overview
-----------

The `composer.json` has a `require` clause to automatically pull in `civicrm-core`.  This relaxes the clause to make it easier to build with `dev-master`. 

Example
---------

Oy.

Suppose you want to run unit-tests for a PR on `civicrm-core` using a build of D9/D10 -- and suppose the patch modifies `composer.json` metadata. Well, that metadata isn't published yet... so you have coax composer into using the new (provisionally modified) `composer.json`. 

You can do this with a ["`path` repository"](https://getcomposer.org/doc/05-repositories.md#path).

```javascript
    "repositories": {
        "civicrm-packages": {
            "type": "path",
            "url": "./src/civicrm-packages"
        },
        "civicrm-core": {
            "type": "path",
            "url": "./src/civicrm-core"
        },
        "civicrm-drupal-8": {
            "type": "path",
            "url": "./src/civicrm-drupal-8"
        },
        "0": {
            "type": "composer",
            "url": "https://packages.drupal.org/8"
        }
    },
```

Then you ask composer to setup these packages:

```bash
composer require civicrm/civicrm-{core,packages,drupal-8}:dev-master --prefer-source
```

And composer does some voodoo.Without this patch, the output of the voodoo is:

```
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires civicrm/civicrm-drupal-8 dev-master -> satisfiable by civicrm/civicrm-drupal-8[dev-master].
    - civicrm/civicrm-drupal-8 dev-master requires civicrm/civicrm-core >=5.21.0 -> satisfiable by civicrm/civicrm-core[dev-master, 5.21.0, ..., 5.73.x-dev] from composer repo (https://repo.packagist.org) but
civicrm/civicrm-core[dev-master] from path repo (./src/civicrm-core) has higher repository priority. The packages from the higher priority repository do not match your constraint and are therefore not installa
ble. That repository is canonical so the lower priority repo's packages are not installable. See https://getcomposer.org/repoprio for details and assistance.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
```

Now, this is a very strange voodoo chant. It seems to say that the constraint `>=5.21.0` can be satisfied implicitly by `dev-master`... but ***only*** if `dev-master` comes from `packagist.org`.  If you have some other `dev-master` (by an alternate `path`), then it's not automatically allowed.

Comments
-----------

Testing this is annoying. It's not really worth while for anyone else to bother. Key facts:

* The updated constraint is basically the same as before. The declaration is equally sensible.
* We won't truly know that it all works until this new metadata is published.
* To the extent that it's possible to simulate locally (by mixing `path` and/or `vcs` repositories), this seems to solve the problem.