### PR TITLE
check to see if permission description is not an array

### DIFF
--- a/src/CivicrmPermissions.php
+++ b/src/CivicrmPermissions.php
@@ -38,12 +38,10 @@ class CivicrmPermissions implements ContainerInjectionInterface {
   public function permissions() {
     $permissions = [];
     foreach (\CRM_Core_Permission::basicPermissions(FALSE, TRUE) as $permission => $attr) {
-      $title = array_shift($attr);
-      $permissions[$permission] = ['title' => $title];
+      $permissions[$permission] = ['title' => $attr['label']];
 
-      $description = array_shift($attr);
-      if (!empty($description) && !is_array($description)) {
-        $permissions[$permission]['description'] = $description;
+      if (!empty($attr['description'])) {
+        $permissions[$permission]['description'] = $attr['description'];
       }
     }
     return $permissions;

--- a/src/CivicrmPermissions.php
+++ b/src/CivicrmPermissions.php
@@ -42,7 +42,7 @@ class CivicrmPermissions implements ContainerInjectionInterface {
       $permissions[$permission] = ['title' => $title];
 
       $description = array_shift($attr);
-      if (!empty($description) && !is_array($description) {
+      if (!empty($description) && !is_array($description)) {
         $permissions[$permission]['description'] = $description;
       }
     }

--- a/src/CivicrmPermissions.php
+++ b/src/CivicrmPermissions.php
@@ -42,7 +42,7 @@ class CivicrmPermissions implements ContainerInjectionInterface {
       $permissions[$permission] = ['title' => $title];
 
       $description = array_shift($attr);
-      if (!empty($description)) {
+      if (!empty($description) && !is_array($description) {
         $permissions[$permission]['description'] = $description;
       }
     }


### PR DESCRIPTION
Getting reports of a error on Drupal permissions pages. 
https://civicrm.stackexchange.com/questions/47847/user-error-0-is-an-invalid-render-array-key-in-drupal-core-render-elementch
and
https://lab.civicrm.org/dev/drupal/-/issues/199
https://chat.civicrm.org/civicrm/pl/93imiak3z7b4iqntguuw3x5p5c

Possibly changes here caused this condition: https://github.com/civicrm/civicrm-core/pull/29173

