### PR TITLE
Generate URLs faster - another attempt

### DIFF
--- a/src/PathProcessor/CivicrmPathProcessor.php
+++ b/src/PathProcessor/CivicrmPathProcessor.php
@@ -29,10 +29,10 @@ class CivicrmPathProcessor implements InboundPathProcessorInterface {
       $civicrm = new Civicrm();
       $civicrm->initialize();
       // Fetch civicrm menu items.
-      $items = \Civi::cache('long')->get(__CLASS__ . '-Core_Menu_items');
+      $items = \Civi::cache('long')->get('CivicrmPathProcessor-Core_Menu_items');
       if (empty($items)) {
         $items = \CRM_Core_Menu::items();
-        \Civi::cache('long')->set(__CLASS__ . '-Core_Menu_items', $items);
+        \Civi::cache('long')->set('CivicrmPathProcessor-Core_Menu_items', $items);
       }
       \Civi::$statics[__CLASS__]['knownPaths'][$path] = $path;
       $longest = '';


### PR DESCRIPTION
Another attempt at https://github.com/civicrm/civicrm-drupal-8/pull/88

This one seems to work with the edge cases we were having trouble with:
* cache clear
* weirdo urls like civicrm/report/instance/14 where the parameter is part of the path
* oddballs like the civicrm/upgrade queue runner

I have not yet tested the installer or done any benchmarking on speed. Going to do that next.

There's pros and cons to using Civi::cache instead of Civi::statics for storing the menu items, which is the bulk of the problem. It seems to work with either but at the moment I've used cache.
For the known paths, I'm not sure we need to even cache those if we're caching the menu build, but I've left that in.

@MegaphoneJon @jackrabbithanna 