### PR TITLE
don't do install requirements check on every status check

### DIFF
--- a/civicrm.install
+++ b/civicrm.install
@@ -88,14 +88,16 @@ function civicrm_requirements($phase) {
     'other' => 'CiviCRM: Other',
   ];
 
-  foreach ($setup->checkRequirements()->getMessages() as $msg) {
-    $section = isset($sections[$msg['section']]) ? $sections[$msg['section']] : $sections['other'];
-    $key = 'civicrm.' . $msg['section'] . '.' . $msg['name'];
-    $requirements[$key] = [
-      'title' => $section . ': ' . $msg['message'],
-      'description' => $section . ': ' . $msg['message'],
-      'severity' => $severityMap[$msg['severity']],
-    ];
+  if ($phase !== 'runtime') {
+    foreach ($setup->checkRequirements()->getMessages() as $msg) {
+      $section = isset($sections[$msg['section']]) ? $sections[$msg['section']] : $sections['other'];
+      $key = 'civicrm.' . $msg['section'] . '.' . $msg['name'];
+      $requirements[$key] = [
+        'title' => $section . ': ' . $msg['message'],
+        'description' => $section . ': ' . $msg['message'],
+        'severity' => $severityMap[$msg['severity']],
+      ];
+    }
   }
 
   ksort($requirements);


### PR DESCRIPTION
Quoting [hook_requirements](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Extension%21module.api.php/function/hook_requirements/10):

> This hook has three closely related uses, determined by the $phase argument:
>
>   Checking installation requirements ($phase == 'install').
>    Checking update requirements ($phase == 'update').
>    Status reporting ($phase == 'runtime').

Pre-installation, CiviCRM does a number of checks that post-install are handled by `CRM_Utils_Check_*`.  However, we continue to do these checks (adding and dropping tables, triggers, testing the connection, etc.) every time the Drupal status report is run.

In my use case, where I monitor it with the "nagios" module, that means that every 5 minutes, we're needlessly doing all these database writes.

This patch modifies `civicrm.install` so that these checks are only done on install and upgrade.