### PR TITLE
Use a static var for initialized guard for Drupal\civicrm\Civicrm 

### DIFF
--- a/src/Civicrm.php
+++ b/src/Civicrm.php
@@ -3,7 +3,6 @@
 namespace Drupal\civicrm;
 
 use Drupal\civicrm\Exception\CiviCRMConfigException;
-use Drupal\Core\Config\ConfigException;
 use Drupal\Core\Session\AccountInterface;
 
 /**

--- a/src/Civicrm.php
+++ b/src/Civicrm.php
@@ -16,7 +16,7 @@ class Civicrm {
    *
    * @var bool
    */
-  protected $initialized = FALSE;
+  protected static $initialized = FALSE;
 
   /**
    * Initialize CiviCRM.
@@ -24,7 +24,7 @@ class Civicrm {
    * Call this function from other modules too if they use the CiviCRM API.
    */
   public function initialize() {
-    if ($this->initialized) {
+    if ($this->isInitialized()) {
       return;
     }
 
@@ -61,14 +61,14 @@ class Civicrm {
     \CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
 
     // Mark CiviCRM as initialized.
-    $this->initialized = TRUE;
+    static::$initialized = TRUE;
   }
 
   /**
    * Checks if the CiviCRM link is already initialized.
    */
   public function isInitialized() {
-    return $this->initialized;
+    return static::$initialized;
   }
 
   /**
@@ -78,7 +78,7 @@ class Civicrm {
    */
   public function invoke($args) {
     $this->initialize();
-    
+
     // Add CSS, JS, etc. that is required for this page.
     \CRM_Core_Resources::singleton()->addCoreResources();
 


### PR DESCRIPTION
This changes the `initialized` variable on the class from an instance var to a static var to prevent re-initialisation globally.

Pertinent case - don't reinitialise every time a URL is generated by `Drupal\civicrm\PathProcessor\CivicrmPathProcessor`

Fixes an occurrence of [this bug](https://lab.civicrm.org/dev/core/-/issues/4478) for me and should improve performance (e.g. generating search kit button links)