### PR TITLE
Missing route cachability metadata in CiviCRM

### DIFF
--- a/src/CivicrmBreadcrumbBuilder.php
+++ b/src/CivicrmBreadcrumbBuilder.php
@@ -4,6 +4,7 @@ namespace Drupal\civicrm;
 
 use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
 use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Link;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -30,8 +31,12 @@ class CivicrmBreadcrumbBuilder implements BreadcrumbBuilderInterface {
   /**
    * {@inheritdoc}
    */
-  public function applies(RouteMatchInterface $route_match) {
+  public function applies(RouteMatchInterface $route_match, ?CacheableMetadata $cacheable_metadata = NULL) {
     $route_object = $route_match->getRouteObject();
+
+    if ($cacheable_metadata) {
+      $cacheable_metadata->addCacheContexts(['route']);
+    }
 
     // No route object is defined, so we can't inspect it.
     if (!$route_object) {


### PR DESCRIPTION
This is the same as #102 but with the style fails fixed and commits squashed.