### PR TITLE
Customizable name in user/edit/profile as in user/edit

### DIFF
--- a/src/Form/UserProfile.php
+++ b/src/Form/UserProfile.php
@@ -89,7 +89,7 @@ class UserProfile extends FormBase {
     $html .= \CRM_Core_Region::instance('form-bottom')->render('', FALSE);
     \CRM_Core_Resources::singleton()->addCoreResources();
 
-    $form['#title'] = $this->user->getAccountName();
+    $form['#title'] = $this->user->getDisplayName();
     $form['#attributes'] = ['enctype' => "multipart/form-data"];
     $form['form'] = [
       '#type' => 'fieldset',


### PR DESCRIPTION
Simple change to allow the use of `hook_user_format_name_alter` for the CiviCRM profile edit page the same way it's possible for user/edit page (e.g. if we want to display the name from CiviCRM).

To test:
- create a `hook_user_format_name_alter` to change the username
- in `user/edit` the hook is applied
- create a profile that is used for Drupal View/Edit:
![Screenshot 2025-06-11 at 15-15-57 Profiles CiviCRM Sandbox on Drupal 10](https://github.com/user-attachments/assets/bd1e703b-aef8-48a5-ab73-75541f62bb5e)
- in the `user/xx/edit/profile/yy` page, the `hook_user_format_name_alter` was not applied
