### PR TITLE
satisfy phpcs - var declarations

### DIFF
--- a/src/Form/UserProfile.php
+++ b/src/Form/UserProfile.php
@@ -25,17 +25,12 @@ class UserProfile extends FormBase {
   protected $user;
 
   /**
-   *
-   */
-  protected $profile;
-
-  /**
-   *
+   * @var int
    */
   protected $contactId;
 
   /**
-   *
+   * @var array
    */
   protected $ufGroup;
 
@@ -72,7 +67,6 @@ class UserProfile extends FormBase {
     // Make the controller state available to form overrides.
     $form_state->set('controller', $this);
     $this->user = $user;
-    $this->profile = $profile;
 
     // Search for the profile form, otherwise generate a 404.
     $uf_groups = \CRM_Core_BAO_UFGroup::getModuleUFGroup('User Account');


### PR DESCRIPTION
The style errors predate when phpcs started being applied to this repo.

* One of the class members is only ever a local var so it can go. I don't see anywhere this class is extended inside or outside this repo, and why would it be since it's the tab on the drupal user for a civi profile.
* Added `@var` docblock for the other two.