### PR TITLE
[REF] use CivicrmPageState::addHtmlHeader directly

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -33,13 +33,13 @@ function civicrm_page_attachments(array &$page) {
   // Always add core styles (even if not on a /civicrm page).
   CRM_Core_Resources::singleton()->addCoreStyles();
 
-  // Merge CiviCRM stuff into HTML header.
-  if ($region = \CRM_Core_Region::instance('html-header', FALSE)) {
-    \CRM_Utils_System::addHTMLHead($region->render(''));
-  }
-
   /** @var \Drupal\civicrm\CivicrmPageState $page_state */
   $page_state = \Drupal::service('civicrm.page_state');
+
+  // Merge CiviCRM stuff into HTML header.
+  if ($region = \CRM_Core_Region::instance('html-header', FALSE)) {
+    $page_state->addHtmlHeader($region->render(''));
+  }
 
   // Attach CSS and JS.
   foreach ($page_state->getCSS() as $counter => $css) {


### PR DESCRIPTION
Before
------------------
- `civicrm.module` uses `CRM_Utils_System::addHTMLHead` which in turn  `CRM_Utils_System::addHTMLHead` in turn just calls `CivicrmPageState::addHtmlHeader` (ie we hop across to `civicrm-core` and back again)
- `CRM_Utils_System::addHTMLHead` is on a slow deprecation path, deprecated in WP and Standalone but not Drupal/BD

After
------------------- 
-`civicrm.module` uses `CivicrmPageState::addHtmlHeader` directly, no hopping between the repos
- we can think about deprecating `CRM_Utils_System::addHTMLHead` in D8+ too

