### PR TITLE
add cache tag to pages with civicrm content

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -57,6 +57,10 @@ function civicrm_page_attachments(array &$page) {
     '#markup' => Markup::create($headers),
   ];
   $page['#attached']['html_head'][] = [$markup, 'civicrm-headers'];
+
+  // if we load CiviCRM content on a page, we add a general cache tag
+  // so we can invalidate Drupal's cache when CiviCRM is flushed
+  $page['#cache']['tags'][] = 'civicrm';
 }
 
 /**


### PR DESCRIPTION
I'm investigating a bug with Drupal page caching. I think this may be part of the solution.

More soon...