### PR TITLE
Increase priority of service civicrmtheme.negotiator to make civicrmtheme work with other theme negotiator services (e.g. domain_theme_switch)

### DIFF
--- a/modules/civicrmtheme/civicrmtheme.services.yml
+++ b/modules/civicrmtheme/civicrmtheme.services.yml
@@ -3,4 +3,4 @@ services:
     class: Drupal\civicrmtheme\Theme\CivicrmThemeNegotiator
     arguments: ['@current_user', '@config.factory', '@civicrm']
     tags:
-      - { name: theme_negotiator, priority: 0 }
+      - { name: theme_negotiator, priority: 11 }


### PR DESCRIPTION
The submodule civicrmtheme enables us to select a CiviCRM admim theme and public theme.

This is done with the service CivicrmThemeNegotiator, `civicrmtheme.services.yml` sets `priority: 0`.

If we have other drupal modules 
* implementing a ThemeNegotiator service with a *higher* priority 
* that service is checked before the civicrmtheme service
* and if this other services "applies" (i.e. it's implementation of `ThemeNegotiatorInterface::applies()` returns TRUE)
* the civicrmtheme service is never asked
* and the selection for CiviCRM admim theme and public theme are ignored.

That happens because
> the first negotiator returning a theme name wins

https://drupal.stackexchange.com/questions/281447/themenegotiator-not-working-for-admin-pages


In our example we used the contrib module [domain_theme_switch](https://www.drupal.org/project/domain_theme_switch) (building on top of [domain](https://www.drupal.org/project/domain) to use a different theme per domain).
That caused:
* CiviCRM backend pages shown with the domain frontend theme (instead of the CiviCRM theme selected via civicrmtheme)
* and because this particular frontend theme used it's own bootstrap javascript
* the Dropdown-Buttons were not working

The same problem would occur with any other ThemeNegotiator service with a *higher* priority than `0`.

As a solution we increased the priority of civicrmtheme service to 11.