### PR TITLE
Add permission check on contact being accessed through user/profile

### DIFF
--- a/src/Form/UserProfile.php
+++ b/src/Form/UserProfile.php
@@ -136,10 +136,11 @@ class UserProfile extends FormBase {
   /**
    * Controls access for this form.
    */
-  public function access($profile) {
+  public function access($profile, $user) {
     $uf_groups = \CRM_Core_BAO_UFGroup::getModuleUFGroup('User Account', 0, FALSE, \CRM_Core_Permission::EDIT);
+    $cid = \CRM_Core_BAO_UFMatch::getContactId($user);
 
-    if (isset($uf_groups[$profile])) {
+    if (isset($uf_groups[$profile]) && isset($cid) && \CRM_Contact_BAO_Contact_Permission::allow($cid, \CRM_Core_Permission::EDIT)) {
       return AccessResult::allowed();
     }
     return AccessResult::forbidden();


### PR DESCRIPTION
**BEFORE:**

User x

   * with Profile edit permission
   * is logged in
   * edits their account (/user/x/edit)
   * changes tabs to access a profile that was exposed to "View/Edit Drupal User Account" (e.g. /user/x/edit/profile/2)
   * changes the user id in the url to another than their own (e.g. /user/y/edit/profile/2)

Can

   * see the username of user y (which could be their email)
   * see a Save button
   * modify user y's data (explaining how is out of my league but this was reported in a security audit)

**AFTER:**

   * User x can only access the profile for user y if they have permission to edit user y's contact record
   * Otherwise access is denied

PR created with @samuelsov
